### PR TITLE
[#15] Replaced conjars repo in build.bst

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -178,7 +178,7 @@ libraryDependencies ++= Seq(
   "org.jboss.aerogear" % "aerogear-otp-java" % "1.0.0"
 )
 
-resolvers += "Cascading Conjars" at "http://conjars.org/repo/"
+resolvers += "Cascading Conjars" at "https://conjars.wensel.net/repo/"
 
 // Spark 2.0
 libraryDependencies ++= Seq(


### PR DESCRIPTION
Replaced the old repository https://conjars.org/repo with https://conjars.wensel.net/repo/ in build.bst file.

