### PR TITLE
162 csjba  error en generación de reportes

### DIFF
--- a/app/reporting/PdfGenerator.scala
+++ b/app/reporting/PdfGenerator.scala
@@ -26,10 +26,6 @@ class PdfGenerator() {
   val xhtml: Boolean = false
   /** HTML tidy checker / prettyprinter instance for XHTML strict parsing */
 
-  val fontPath = "app/assets/stylesheets/report/DejaVuSans.ttf"
-  private val renderer = new ITextRenderer()
-  renderer.getFontResolver.addFont(fontPath, BaseFont.IDENTITY_H, BaseFont.EMBEDDED)
-
   private lazy val tidyParser = {
     val t = new Tidy()
     t.setXHTML(true)

--- a/app/reporting/ReportingModule.scala
+++ b/app/reporting/ReportingModule.scala
@@ -21,7 +21,7 @@ class ReportingModule () extends AbstractModule {
   @Provides
   def providePdfGenerator(): PdfGenerator = {
     val pdfGen = new PdfGenerator()
-    pdfGen.loadLocalFonts(Seq("app/assets/stylesheets/report/DejaVuSans.ttf", "app/assets/stylesheets/report/DejaVuSans-Bold.ttf"))
+    pdfGen.loadTemporaryFonts(Seq("assets/stylesheets/report/DejaVuSans.ttf", "assets/stylesheets/report/DejaVuSans-Bold.ttf"))
     pdfGen
   }
 


### PR DESCRIPTION
Se resolvió el error en la generación de reportes pdf. Había una ruta relativa que funcionaba cuando era ejecutada desde sbt run pero no desde el jar. Se arregló para que ande de ambas maneras. También había un renderer que no se usaba en ningún lado.