### PR TITLE
Fix #246 fallan tests por dependencias

### DIFF
--- a/modules/core/app/controllers/StatusController.scala
+++ b/modules/core/app/controllers/StatusController.scala
@@ -3,8 +3,8 @@ package controllers.core
 import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
 import javax.inject.{Inject, Singleton}
 import play.api.libs.json.Json
-import com.unboundid.ldap.sdk.{LDAPConnection, LDAPConnectionPool}
-import scala.util.{Failure, Success, Try}
+import user.LdapHealthService
+import scala.util.{Failure, Success}
 
 /**
  * Status Controller - Migrado a Scala 3 + Play 3
@@ -13,7 +13,7 @@ import scala.util.{Failure, Success, Try}
  * Endpoints: /api/v2/status
  */
 @Singleton
-class StatusController @Inject()(cc: ControllerComponents, ldapPool: LDAPConnectionPool)
+class StatusController @Inject()(cc: ControllerComponents, ldapHealth: LdapHealthService)
   extends AbstractController(cc) {
 
   /**
@@ -58,8 +58,8 @@ class StatusController @Inject()(cc: ControllerComponents, ldapPool: LDAPConnect
   }
 
   def ldapStatus(): Action[AnyContent] = Action {
-    Try(ldapPool.getRootDSE) match {
-      case Success(dse) => Ok(Json.obj("ldap" -> "UP", "vendor" -> dse.getVendorName))
+    ldapHealth.checkStatus() match {
+      case Success((status, vendor)) => Ok(Json.obj("ldap" -> status, "vendor" -> vendor))
       case Failure(e)   => ServiceUnavailable(Json.obj("ldap" -> "DOWN", "error" -> e.getMessage))
     }
   }

--- a/modules/core/app/user/LdapHealthService.scala
+++ b/modules/core/app/user/LdapHealthService.scala
@@ -1,0 +1,14 @@
+package user
+
+import com.unboundid.ldap.sdk.LDAPConnectionPool
+import javax.inject.{Inject, Singleton}
+
+import scala.util.Try
+
+trait LdapHealthService:
+  def checkStatus(): Try[(String, String)]
+
+@Singleton
+class LdapHealthServiceImpl @Inject()(pool: LDAPConnectionPool) extends LdapHealthService:
+  override def checkStatus(): Try[(String, String)] =
+    Try(pool.getRootDSE).map(dse => ("UP", dse.getVendorName))

--- a/modules/core/app/user/UsersModule.scala
+++ b/modules/core/app/user/UsersModule.scala
@@ -25,3 +25,4 @@ class UsersModule(environment: Environment, conf: Configuration) extends Abstrac
 
     bind(classOf[UserRepository]).to(classOf[LdapUserRepository])
     bind(classOf[RoleRepository]).to(classOf[LdapRoleRepository])
+    bind(classOf[LdapHealthService]).to(classOf[LdapHealthServiceImpl])

--- a/modules/core/test/fixtures/ServiceStubs.scala
+++ b/modules/core/test/fixtures/ServiceStubs.scala
@@ -1,6 +1,7 @@
 package fixtures
 
 import scala.concurrent.Future
+import scala.util.{Success, Try}
 import javax.inject.Singleton
 
 import configdata.{BioMaterialType, CrimeType, CrimeTypeService, BioMaterialTypeService}
@@ -104,3 +105,8 @@ class StubStrKitService extends StrKitService:
   override def delete(id: String) = deleteResult
   override def deleteAlias(id: String) = deleteAliasResult
   override def deleteLocus(id: String) = deleteLocusResult
+
+@Singleton
+class StubLdapHealthService extends user.LdapHealthService:
+  var result: Try[(String, String)] = Success(("UP", "StubVendor"))
+  override def checkStatus(): Try[(String, String)] = result

--- a/modules/core/test/integration/controllers/AuthenticationTest.scala
+++ b/modules/core/test/integration/controllers/AuthenticationTest.scala
@@ -9,6 +9,8 @@ import play.api.test._
 import play.api.test.Helpers._
 import play.api.libs.json.Json
 
+import com.unboundid.ldap.sdk.LDAPConnectionPool
+import org.mockito.Mockito.mock as mockOf
 import security.{UserRepository, StubUserRepository}
 import user.{RoleRepository, UsersModule}
 import security.StubRoleRepository
@@ -27,7 +29,8 @@ class AuthenticationTest extends PlaySpec with GuiceOneAppPerTest {
       .overrides(
         bind[UserRepository].to[StubUserRepository],
         bind[RoleRepository].to[StubRoleRepository],
-        bind[StrKitService].toInstance(new StubStrKitService)
+        bind[StrKitService].toInstance(new StubStrKitService),
+        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
       )
       .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()

--- a/modules/core/test/integration/controllers/AuthenticationTest.scala
+++ b/modules/core/test/integration/controllers/AuthenticationTest.scala
@@ -9,13 +9,11 @@ import play.api.test._
 import play.api.test.Helpers._
 import play.api.libs.json.Json
 
-import com.unboundid.ldap.sdk.LDAPConnectionPool
-import org.mockito.Mockito.mock as mockOf
+import fixtures.{StubLdapHealthService, StubStrKitService}
 import security.{UserRepository, StubUserRepository}
-import user.{RoleRepository, UsersModule}
+import user.{LdapHealthService, RoleRepository, UsersModule}
 import security.StubRoleRepository
 import kits.{StrKitModule, StrKitService}
-import fixtures.StubStrKitService
 
 class AuthenticationTest extends PlaySpec with GuiceOneAppPerTest {
 
@@ -30,7 +28,7 @@ class AuthenticationTest extends PlaySpec with GuiceOneAppPerTest {
         bind[UserRepository].to[StubUserRepository],
         bind[RoleRepository].to[StubRoleRepository],
         bind[StrKitService].toInstance(new StubStrKitService),
-        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
+        bind[LdapHealthService].toInstance(new StubLdapHealthService)
       )
       .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()

--- a/modules/core/test/integration/controllers/BioMaterialTypesTest.scala
+++ b/modules/core/test/integration/controllers/BioMaterialTypesTest.scala
@@ -9,12 +9,10 @@ import play.api.test.*
 import play.api.test.Helpers.*
 import play.api.libs.json.Json
 
-import com.unboundid.ldap.sdk.LDAPConnectionPool
-import org.mockito.Mockito.mock as mockOf
 import configdata.{BioMaterialType, BioMaterialTypeService}
-import fixtures.{StubBioMaterialTypeService, StubStrKitService}
+import fixtures.{StubBioMaterialTypeService, StubLdapHealthService, StubStrKitService}
 import security.{StubRoleRepository, StubUserRepository, UserRepository}
-import user.{RoleRepository, UsersModule}
+import user.{LdapHealthService, RoleRepository, UsersModule}
 import kits.{StrKitModule, StrKitService}
 import types.AlphanumericId
 
@@ -32,7 +30,7 @@ class BioMaterialTypesTest extends PlaySpec with GuiceOneAppPerTest {
         bind[RoleRepository].to[StubRoleRepository],
         bind[BioMaterialTypeService].toInstance(bmtStub),
         bind[StrKitService].toInstance(new StubStrKitService),
-        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
+        bind[LdapHealthService].toInstance(new StubLdapHealthService)
       )
       .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()

--- a/modules/core/test/integration/controllers/BioMaterialTypesTest.scala
+++ b/modules/core/test/integration/controllers/BioMaterialTypesTest.scala
@@ -9,6 +9,8 @@ import play.api.test.*
 import play.api.test.Helpers.*
 import play.api.libs.json.Json
 
+import com.unboundid.ldap.sdk.LDAPConnectionPool
+import org.mockito.Mockito.mock as mockOf
 import configdata.{BioMaterialType, BioMaterialTypeService}
 import fixtures.{StubBioMaterialTypeService, StubStrKitService}
 import security.{StubRoleRepository, StubUserRepository, UserRepository}
@@ -29,7 +31,8 @@ class BioMaterialTypesTest extends PlaySpec with GuiceOneAppPerTest {
         bind[UserRepository].to[StubUserRepository],
         bind[RoleRepository].to[StubRoleRepository],
         bind[BioMaterialTypeService].toInstance(bmtStub),
-        bind[StrKitService].toInstance(new StubStrKitService)
+        bind[StrKitService].toInstance(new StubStrKitService),
+        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
       )
       .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()

--- a/modules/core/test/integration/controllers/CategoriesControllerTest.scala
+++ b/modules/core/test/integration/controllers/CategoriesControllerTest.scala
@@ -1,9 +1,7 @@
 package controllers
 
-import com.unboundid.ldap.sdk.LDAPConnectionPool
 import configdata._
-import fixtures.{StubCategoryService, StubStrKitService}
-import org.mockito.Mockito.mock as mockOf
+import fixtures.{StubCategoryService, StubLdapHealthService, StubStrKitService}
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerTest
@@ -14,7 +12,7 @@ import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import security.{StubRoleRepository, StubUserRepository, UserRepository}
-import user.{RoleRepository, UsersModule}
+import user.{LdapHealthService, RoleRepository, UsersModule}
 import kits.{StrKitModule, StrKitService}
 import types.AlphanumericId
 
@@ -31,7 +29,7 @@ class CategoriesControllerTest extends AnyWordSpec with Matchers with GuiceOneAp
         bind[UserRepository].to[StubUserRepository],
         bind[RoleRepository].to[StubRoleRepository],
         bind[StrKitService].toInstance(new StubStrKitService),
-        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
+        bind[LdapHealthService].toInstance(new StubLdapHealthService)
       )
       .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()

--- a/modules/core/test/integration/controllers/CategoriesControllerTest.scala
+++ b/modules/core/test/integration/controllers/CategoriesControllerTest.scala
@@ -1,7 +1,9 @@
 package controllers
 
+import com.unboundid.ldap.sdk.LDAPConnectionPool
 import configdata._
-import fixtures.StubCategoryService
+import fixtures.{StubCategoryService, StubStrKitService}
+import org.mockito.Mockito.mock as mockOf
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerTest
@@ -11,6 +13,9 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import security.{StubRoleRepository, StubUserRepository, UserRepository}
+import user.{RoleRepository, UsersModule}
+import kits.{StrKitModule, StrKitService}
 import types.AlphanumericId
 
 import scala.concurrent.Future
@@ -19,7 +24,16 @@ class CategoriesControllerTest extends AnyWordSpec with Matchers with GuiceOneAp
 
   override def fakeApplication(): Application =
     GuiceApplicationBuilder()
-      .overrides(bind[CategoryService].to[StubCategoryService])
+      .disable[UsersModule]
+      .disable[StrKitModule]
+      .overrides(
+        bind[CategoryService].to[StubCategoryService],
+        bind[UserRepository].to[StubUserRepository],
+        bind[RoleRepository].to[StubRoleRepository],
+        bind[StrKitService].toInstance(new StubStrKitService),
+        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
+      )
+      .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()
 
   // ─── Category read endpoints ───────────────────────────────────────────────

--- a/modules/core/test/integration/controllers/DisclaimerControllerTest.scala
+++ b/modules/core/test/integration/controllers/DisclaimerControllerTest.scala
@@ -9,12 +9,10 @@ import play.api.test.*
 import play.api.test.Helpers.*
 import play.api.libs.json.Json
 
-import com.unboundid.ldap.sdk.LDAPConnectionPool
-import org.mockito.Mockito.mock as mockOf
 import disclaimer.{Disclaimer, DisclaimerModule, DisclaimerService}
-import fixtures.{StubDisclaimerService, StubStrKitService}
+import fixtures.{StubDisclaimerService, StubLdapHealthService, StubStrKitService}
 import security.{StubRoleRepository, StubUserRepository, UserRepository}
-import user.{RoleRepository, UsersModule}
+import user.{LdapHealthService, RoleRepository, UsersModule}
 import kits.{StrKitModule, StrKitService}
 
 class DisclaimerControllerTest extends PlaySpec with GuiceOneAppPerTest {
@@ -32,7 +30,7 @@ class DisclaimerControllerTest extends PlaySpec with GuiceOneAppPerTest {
         bind[RoleRepository].to[StubRoleRepository],
         bind[DisclaimerService].toInstance(disclaimerStub),
         bind[StrKitService].toInstance(new StubStrKitService),
-        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
+        bind[LdapHealthService].toInstance(new StubLdapHealthService)
       )
       .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()

--- a/modules/core/test/integration/controllers/DisclaimerControllerTest.scala
+++ b/modules/core/test/integration/controllers/DisclaimerControllerTest.scala
@@ -9,6 +9,8 @@ import play.api.test.*
 import play.api.test.Helpers.*
 import play.api.libs.json.Json
 
+import com.unboundid.ldap.sdk.LDAPConnectionPool
+import org.mockito.Mockito.mock as mockOf
 import disclaimer.{Disclaimer, DisclaimerModule, DisclaimerService}
 import fixtures.{StubDisclaimerService, StubStrKitService}
 import security.{StubRoleRepository, StubUserRepository, UserRepository}
@@ -29,7 +31,8 @@ class DisclaimerControllerTest extends PlaySpec with GuiceOneAppPerTest {
         bind[UserRepository].to[StubUserRepository],
         bind[RoleRepository].to[StubRoleRepository],
         bind[DisclaimerService].toInstance(disclaimerStub),
-        bind[StrKitService].toInstance(new StubStrKitService)
+        bind[StrKitService].toInstance(new StubStrKitService),
+        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
       )
       .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()

--- a/modules/core/test/integration/controllers/GeneticistsControllerTest.scala
+++ b/modules/core/test/integration/controllers/GeneticistsControllerTest.scala
@@ -9,12 +9,10 @@ import play.api.test.*
 import play.api.test.Helpers.*
 import play.api.libs.json.Json
 
-import com.unboundid.ldap.sdk.LDAPConnectionPool
-import org.mockito.Mockito.mock as mockOf
-import fixtures.{StubGeneticistService, StubStrKitService, StubUserService}
+import fixtures.{StubGeneticistService, StubLdapHealthService, StubStrKitService, StubUserService}
 import security.{StubRoleRepository, StubUserRepository, UserRepository}
 import services.{GeneticistService, UserService}
-import user.{RoleRepository, UsersModule}
+import user.{LdapHealthService, RoleRepository, UsersModule}
 import kits.{StrKitModule, StrKitService}
 import types.{Geneticist, User}
 
@@ -35,7 +33,7 @@ class GeneticistsControllerTest extends PlaySpec with GuiceOneAppPerTest {
         bind[GeneticistService].toInstance(genStub),
         bind[UserService].toInstance(userStub),
         bind[StrKitService].toInstance(new StubStrKitService),
-        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
+        bind[LdapHealthService].toInstance(new StubLdapHealthService)
       )
       .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()

--- a/modules/core/test/integration/controllers/GeneticistsControllerTest.scala
+++ b/modules/core/test/integration/controllers/GeneticistsControllerTest.scala
@@ -9,6 +9,8 @@ import play.api.test.*
 import play.api.test.Helpers.*
 import play.api.libs.json.Json
 
+import com.unboundid.ldap.sdk.LDAPConnectionPool
+import org.mockito.Mockito.mock as mockOf
 import fixtures.{StubGeneticistService, StubStrKitService, StubUserService}
 import security.{StubRoleRepository, StubUserRepository, UserRepository}
 import services.{GeneticistService, UserService}
@@ -32,7 +34,8 @@ class GeneticistsControllerTest extends PlaySpec with GuiceOneAppPerTest {
         bind[RoleRepository].to[StubRoleRepository],
         bind[GeneticistService].toInstance(genStub),
         bind[UserService].toInstance(userStub),
-        bind[StrKitService].toInstance(new StubStrKitService)
+        bind[StrKitService].toInstance(new StubStrKitService),
+        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
       )
       .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()

--- a/modules/core/test/integration/controllers/LaboratoriesControllerTest.scala
+++ b/modules/core/test/integration/controllers/LaboratoriesControllerTest.scala
@@ -9,6 +9,8 @@ import play.api.test.*
 import play.api.test.Helpers.*
 import play.api.libs.json.Json
 
+import com.unboundid.ldap.sdk.LDAPConnectionPool
+import org.mockito.Mockito.mock as mockOf
 import fixtures.{StubCountryService, StubLaboratoryService, StubStrKitService}
 import security.{StubRoleRepository, StubUserRepository, UserRepository}
 import services.{CountryService, LaboratoryService}
@@ -32,7 +34,8 @@ class LaboratoriesControllerTest extends PlaySpec with GuiceOneAppPerTest {
         bind[RoleRepository].to[StubRoleRepository],
         bind[LaboratoryService].toInstance(labStub),
         bind[CountryService].toInstance(countryStub),
-        bind[StrKitService].toInstance(new StubStrKitService)
+        bind[StrKitService].toInstance(new StubStrKitService),
+        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
       )
       .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()

--- a/modules/core/test/integration/controllers/LaboratoriesControllerTest.scala
+++ b/modules/core/test/integration/controllers/LaboratoriesControllerTest.scala
@@ -9,12 +9,10 @@ import play.api.test.*
 import play.api.test.Helpers.*
 import play.api.libs.json.Json
 
-import com.unboundid.ldap.sdk.LDAPConnectionPool
-import org.mockito.Mockito.mock as mockOf
-import fixtures.{StubCountryService, StubLaboratoryService, StubStrKitService}
+import fixtures.{StubCountryService, StubLaboratoryService, StubLdapHealthService, StubStrKitService}
 import security.{StubRoleRepository, StubUserRepository, UserRepository}
 import services.{CountryService, LaboratoryService}
-import user.{RoleRepository, UsersModule}
+import user.{LdapHealthService, RoleRepository, UsersModule}
 import kits.{StrKitModule, StrKitService}
 import types.Laboratory
 
@@ -35,7 +33,7 @@ class LaboratoriesControllerTest extends PlaySpec with GuiceOneAppPerTest {
         bind[LaboratoryService].toInstance(labStub),
         bind[CountryService].toInstance(countryStub),
         bind[StrKitService].toInstance(new StubStrKitService),
-        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
+        bind[LdapHealthService].toInstance(new StubLdapHealthService)
       )
       .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()

--- a/modules/core/test/integration/controllers/StatusControllerTest.scala
+++ b/modules/core/test/integration/controllers/StatusControllerTest.scala
@@ -8,6 +8,8 @@ import play.api.Application
 import play.api.test._
 import play.api.test.Helpers._
 
+import com.unboundid.ldap.sdk.LDAPConnectionPool
+import org.mockito.Mockito.mock as mockOf
 import security.{UserRepository, StubUserRepository}
 import user.{RoleRepository, UsersModule}
 import security.StubRoleRepository
@@ -23,7 +25,8 @@ class StatusControllerTest extends PlaySpec with GuiceOneAppPerTest {
       .overrides(
         bind[UserRepository].to[StubUserRepository],
         bind[RoleRepository].to[StubRoleRepository],
-        bind[StrKitService].toInstance(new StubStrKitService)
+        bind[StrKitService].toInstance(new StubStrKitService),
+        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
       )
       .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()

--- a/modules/core/test/integration/controllers/StatusControllerTest.scala
+++ b/modules/core/test/integration/controllers/StatusControllerTest.scala
@@ -8,13 +8,11 @@ import play.api.Application
 import play.api.test._
 import play.api.test.Helpers._
 
-import com.unboundid.ldap.sdk.LDAPConnectionPool
-import org.mockito.Mockito.mock as mockOf
+import fixtures.{StubLdapHealthService, StubStrKitService}
 import security.{UserRepository, StubUserRepository}
-import user.{RoleRepository, UsersModule}
+import user.{LdapHealthService, RoleRepository, UsersModule}
 import security.StubRoleRepository
 import kits.{StrKitModule, StrKitService}
-import fixtures.StubStrKitService
 
 class StatusControllerTest extends PlaySpec with GuiceOneAppPerTest {
 
@@ -26,7 +24,7 @@ class StatusControllerTest extends PlaySpec with GuiceOneAppPerTest {
         bind[UserRepository].to[StubUserRepository],
         bind[RoleRepository].to[StubRoleRepository],
         bind[StrKitService].toInstance(new StubStrKitService),
-        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
+        bind[LdapHealthService].toInstance(new StubLdapHealthService)
       )
       .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()

--- a/modules/core/test/integration/controllers/StrKitsControllerTest.scala
+++ b/modules/core/test/integration/controllers/StrKitsControllerTest.scala
@@ -9,12 +9,10 @@ import play.api.test.*
 import play.api.test.Helpers.*
 import play.api.libs.json.Json
 
-import com.unboundid.ldap.sdk.LDAPConnectionPool
-import org.mockito.Mockito.mock as mockOf
-import fixtures.StubStrKitService
+import fixtures.{StubLdapHealthService, StubStrKitService}
 import kits.{FullStrKit, NewStrKitLocus, StrKit, StrKitModule, StrKitService}
 import security.{StubRoleRepository, StubUserRepository, UserRepository}
-import user.{RoleRepository, UsersModule}
+import user.{LdapHealthService, RoleRepository, UsersModule}
 
 class StrKitsControllerTest extends PlaySpec with GuiceOneAppPerTest {
 
@@ -29,7 +27,7 @@ class StrKitsControllerTest extends PlaySpec with GuiceOneAppPerTest {
         bind[UserRepository].to[StubUserRepository],
         bind[RoleRepository].to[StubRoleRepository],
         bind[StrKitService].toInstance(kitStub),
-        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
+        bind[LdapHealthService].toInstance(new StubLdapHealthService)
       )
       .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()

--- a/modules/core/test/integration/controllers/StrKitsControllerTest.scala
+++ b/modules/core/test/integration/controllers/StrKitsControllerTest.scala
@@ -9,6 +9,8 @@ import play.api.test.*
 import play.api.test.Helpers.*
 import play.api.libs.json.Json
 
+import com.unboundid.ldap.sdk.LDAPConnectionPool
+import org.mockito.Mockito.mock as mockOf
 import fixtures.StubStrKitService
 import kits.{FullStrKit, NewStrKitLocus, StrKit, StrKitModule, StrKitService}
 import security.{StubRoleRepository, StubUserRepository, UserRepository}
@@ -26,7 +28,8 @@ class StrKitsControllerTest extends PlaySpec with GuiceOneAppPerTest {
       .overrides(
         bind[UserRepository].to[StubUserRepository],
         bind[RoleRepository].to[StubRoleRepository],
-        bind[StrKitService].toInstance(kitStub)
+        bind[StrKitService].toInstance(kitStub),
+        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
       )
       .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()

--- a/modules/core/test/motive/MotiveControllerSpec.scala
+++ b/modules/core/test/motive/MotiveControllerSpec.scala
@@ -1,7 +1,8 @@
 package motive
 
+import com.unboundid.ldap.sdk.LDAPConnectionPool
 import controllers.MotiveController
-import org.mockito.Mockito.when
+import org.mockito.Mockito.{mock as mockOf, when}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play._
 import org.scalatestplus.play.guice.GuiceOneAppPerTest
@@ -39,7 +40,8 @@ class MotiveControllerSpec extends PlaySpec with GuiceOneAppPerTest with Mockito
       .overrides(
         bind[UserRepository].to[StubUserRepository],
         bind[RoleRepository].to[StubRoleRepository],
-        bind[MotiveService].toInstance(stubMotiveService)
+        bind[MotiveService].toInstance(stubMotiveService),
+        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
       )
       .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()

--- a/modules/core/test/motive/MotiveControllerSpec.scala
+++ b/modules/core/test/motive/MotiveControllerSpec.scala
@@ -1,9 +1,6 @@
 package motive
 
-import com.unboundid.ldap.sdk.LDAPConnectionPool
-import controllers.MotiveController
-import org.mockito.Mockito.{mock as mockOf, when}
-import org.scalatestplus.mockito.MockitoSugar
+import fixtures.StubLdapHealthService
 import org.scalatestplus.play._
 import org.scalatestplus.play.guice.GuiceOneAppPerTest
 import play.api.Application
@@ -12,13 +9,12 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import security.{StubUserRepository, UserRepository}
-import user.{RoleRepository, UsersModule}
-import security.StubRoleRepository
+import security.{StubUserRepository, StubRoleRepository, UserRepository}
+import user.{LdapHealthService, RoleRepository, UsersModule}
 
 import scala.concurrent.Future
 
-class MotiveControllerSpec extends PlaySpec with GuiceOneAppPerTest with MockitoSugar {
+class MotiveControllerSpec extends PlaySpec with GuiceOneAppPerTest {
 
   val stubMotiveService: MotiveService = new MotiveService {
     override def getMotives(motiveType: Long, editable: Boolean): Future[List[Motive]] =
@@ -41,7 +37,7 @@ class MotiveControllerSpec extends PlaySpec with GuiceOneAppPerTest with Mockito
         bind[UserRepository].to[StubUserRepository],
         bind[RoleRepository].to[StubRoleRepository],
         bind[MotiveService].toInstance(stubMotiveService),
-        bind[LDAPConnectionPool].toInstance(mockOf(classOf[LDAPConnectionPool]))
+        bind[LdapHealthService].toInstance(new StubLdapHealthService)
       )
       .configure("play.http.secret.key" -> "test-secret-key-for-testing-purposes-only-not-for-production-1234")
       .build()


### PR DESCRIPTION
Aclaración:
Los primeros dos commits introdujeron cambios revertidos en el tercero. Ese tiene la descripción real de los cambios realizados, los otros quedaron de registro nada más.

 Problema
                                                                                                                                                     
  StatusController inyectaba LDAPConnectionPool directamente. Como Guice instancia todos los controllers registrados en routes al arrancar la app, todos los controller tests que deshabilitaban UsersModule fallaban con CreationException: No injectable constructor for type LDAPConnectionPool.   
                                                                                                                                                     
  Además, CategoriesControllerTest no deshabilitaba UsersModule ni StrKitModule, causando LDAPBindException al intentar conectarse al LDAP real.     
   
  Solución                                                                                                                                           
                                                                                                                                                   
  - Extraer LdapHealthService (trait + LdapHealthServiceImpl) en modules/core/app/user/, bindeado en UsersModule                                     
  - StatusController inyecta el trait en vez del tipo concreto de infraestructura
  - Crear StubLdapHealthService en test/fixtures/ServiceStubs.scala                                                                                  
  - Actualizar los 9 controller tests para usar el stub y deshabilitar los módulos de infraestructura                                                
                                                                                                                                                     
  Patrón establecido                                                                                                                                 
                                                                                                                                                     
  Los controllers nunca deben inyectar tipos concretos de infraestructura externa (LDAPConnectionPool, Database, etc.). Siempre envolverlos en un trait propio del proyecto para que los tests usen stubs en vez de mocks de clases externas. (Documentado en mi CLAUDE.md. )  