### PR TITLE
Fix #268 Restore LRResult.scala lost in merge conflict resolution

### DIFF
--- a/modules/core/app/probability/LRResult.scala
+++ b/modules/core/app/probability/LRResult.scala
@@ -1,38 +1,36 @@
 package probability
 
-
-import play.api.libs.functional.syntax.*
 import play.api.libs.json.*
-
+import play.api.libs.functional.syntax.*
 import profile.Profile
 
 import scala.util.Try
 
 case class LRResult(total: Double, detailed: Map[Profile.Marker, Option[Double]])
 
-object LRResult {
+object LRResult:
 
-  implicit val doubleReads: Reads[Double] = new Reads[Double] {
-    def reads(jv: JsValue): JsResult[Double] = JsSuccess(Try(jv.asInstanceOf[JsString].value.toDouble).getOrElse(1))
-  }
+  implicit val doubleReads: Reads[Double] = Reads:
+    case JsNumber(n) => JsSuccess(n.toDouble)
+    case JsString(s) => JsSuccess(Try(s.toDouble).getOrElse(1.0))
+    case _ => JsError("Expected number or string")
 
-  implicit val doubleWrites: Writes[Double] = new Writes[Double] {
-    def writes(l: Double): JsValue = Json.toJson(l.toString)
-  }
+  implicit val doubleWrites: Writes[Double] = Writes(l => JsString(l.toString))
 
-  implicit val odoubleReads: Reads[Option[Double]] = new Reads[Option[Double]] {
-    def reads(jv: JsValue): JsResult[Option[Double]] = JsSuccess(Try(jv.asInstanceOf[JsString].value.toDouble).toOption)
-  }
+  implicit val odoubleReads: Reads[Option[Double]] = Reads:
+    case JsString(s) => JsSuccess(Try(s.toDouble).toOption)
+    case JsNumber(n) => JsSuccess(Some(n.toDouble))
+    case JsNull => JsSuccess(None)
+    case _ => JsError("Expected string, number, or null")
 
   implicit val lrResultReads: Reads[LRResult] = (
     (__ \ "total").read[Double] ~
-      (__ \ "detailed").read[Map[Profile.Marker, Option[Double]]]
-  )(LRResult.apply)
+    (__ \ "detailed").read[Map[Profile.Marker, Option[Double]]]
+  )(LRResult.apply _)
 
   implicit val lrResultWrites: OWrites[LRResult] = (
     (__ \ "total").write[Double] ~
-      (__ \ "detailed").write[Map[Profile.Marker, Option[Double]]]
+    (__ \ "detailed").write[Map[Profile.Marker, Option[Double]]]
   )((lrResult: LRResult) => (lrResult.total, lrResult.detailed))
 
   implicit val lrResultFormat: OFormat[LRResult] = OFormat(lrResultReads, lrResultWrites)
-}


### PR DESCRIPTION
The merge took the version that only handled JsString, discarding the one that also handles JsNumber and JsNull.