### PR TITLE
Fix #294 Memoizar findSuperUsers() (TTL 30s) para no disparar una búsqueda LDAP

### DIFF
--- a/app/user/LdapConnectionPoolFactory.scala
+++ b/app/user/LdapConnectionPoolFactory.scala
@@ -1,6 +1,7 @@
 package user
 
 import com.unboundid.ldap.sdk.LDAPConnection
+import com.unboundid.ldap.sdk.LDAPConnectionOptions
 import com.unboundid.ldap.sdk.LDAPConnectionPool
 import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig
 import com.unboundid.ldap.listener.InMemoryDirectoryServer
@@ -26,7 +27,20 @@ class LdapConnectionPoolFactory(conf: Configuration) {
     if (ldapConf.url.startsWith("memserver")) {
       inMemoryServer.getConnection()
     } else {
-      new LDAPConnection(ldapConf.url, ldapConf.port)
+      // If this connection dies (e.g. TCP reset under a search burst) it is
+      // never re-established: every LDAP-dependent action fails with
+      // resultCode=81 until the app is restarted (incident 2026-07-09,
+      // CDMX deployment). setAutoReconnect covers the incident's death mode,
+      // verified against unboundid-ldapsdk 2.3.1 on the asyncSearch path: if
+      // the server kills this connection but stays up, the SDK re-establishes
+      // it (one immediate attempt on disconnect, plus attempts on send
+      // failure, throttled to one per second). It does NOT survive an LDAP
+      // server restart: a reconnect attempt against an unreachable server
+      // tears the connection down for good ("not established") and nothing
+      // ever retries after that — surviving that needs a connection pool.
+      val options = new LDAPConnectionOptions()
+      options.setAutoReconnect(true)
+      new LDAPConnection(options, ldapConf.url, ldapConf.port)
     }
   }
 

--- a/app/user/UserService.scala
+++ b/app/user/UserService.scala
@@ -343,8 +343,27 @@ class UserServiceImpl @Inject() (
     findByGeneMapper(geneMapperId).map(userOption => userOption.get.superuser)
   }
 
+  // sendNotifToAllSuperUsers is invoked once per match / per proto-profile
+  // when a batch is accepted (Spark2Matcher, BulkUploadService): each call
+  // used to fire a full LDAP search "(title=true)" over the single shared
+  // search connection, in bursts of 300+ searches per second that killed it
+  // by backpressure (resultCode=81; incident 2026-07-09, CDMX deployment).
+  // Memoize the Future for a short TTL: concurrent calls share the in-flight
+  // search and the list (which almost never changes) refreshes by itself.
+  private val superUsersTtlMillis = 30000L
+  @volatile private var superUsersCached: Option[(Long, Future[Seq[String]])] = None
+
   override def findSuperUsers(): Future[Seq[String]] = {
-    userRepository.findSuperUsers().map(_.map(LdapUser.toUser(_, roleService.getRolePermissions())).map(_.id)).map(_.toSet.toSeq)
+    val now = System.currentTimeMillis()
+    superUsersCached match {
+      case Some((ts, cached)) if now - ts < superUsersTtlMillis => cached
+      case _ =>
+        val fresh = userRepository.findSuperUsers().map(_.map(LdapUser.toUser(_, roleService.getRolePermissions())).map(_.id)).map(_.toSet.toSeq)
+        superUsersCached = Some((now, fresh))
+        // never cache a failure (e.g. LDAP briefly down)
+        fresh.onFailure { case _ => superUsersCached = None }
+        fresh
+    }
   }
 
   override def sendNotifToAllSuperUsers(info: NotificationInfo, excepThis: Seq[String]) = {

--- a/test/user/UserServiceSuperUsersTest.scala
+++ b/test/user/UserServiceSuperUsersTest.scala
@@ -1,0 +1,102 @@
+package user
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.mockito.Mockito.when
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import stubs.Stubs
+import types.Permission
+import types.Permission.USER_CRUD
+
+import scala.collection.immutable.HashMap
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.SECONDS
+
+/**
+ * findSuperUsers is called once per match / per proto-profile when a batch
+ * is accepted, so it must not fire one LDAP search per call (incident
+ * 2026-07-09: bursts of 300+ identical searches per second killed the single
+ * shared search connection). These tests exercise the memoization only, with
+ * a mocked repository: no LDAP / database needed.
+ */
+class UserServiceSuperUsersTest extends PlaySpec with MockitoSugar {
+
+  val duration = Duration(10, SECONDS)
+  val rolePermissions: Map[String, Set[Permission]] =
+    HashMap("clerk" -> Set(USER_CRUD), "geneticist" -> Set(USER_CRUD))
+
+  "UserService findSuperUsers" must {
+
+    "fire a single ldap search for a burst of calls" in {
+
+      val searchCount = new AtomicInteger(0)
+      val inFlight = Promise[Seq[LdapUser]]()
+      val userRepo = mock[UserRepository]
+      when(userRepo.findSuperUsers()).thenAnswer(new Answer[Future[Seq[LdapUser]]] {
+        override def answer(invocation: InvocationOnMock): Future[Seq[LdapUser]] = {
+          searchCount.incrementAndGet()
+          inFlight.future
+        }
+      })
+      val roleService = mock[RoleService]
+      when(roleService.getRolePermissions()).thenReturn(rolePermissions)
+
+      val userService = new UserServiceImpl(userRepo, null, null, null, null, roleService)
+
+      // burst like the one fired per accepted batch (one call per match):
+      // the calls keep coming while the ldap search is still in flight
+      val burst = (1 to 300).map { _ => userService.findSuperUsers() }
+
+      searchCount.get mustBe 1
+
+      inFlight.success(Seq(Stubs.ldapUser))
+
+      burst.foreach { future =>
+        Await.result(future, duration) mustBe Seq("user")
+      }
+      searchCount.get mustBe 1
+    }
+
+    "not keep a failed search cached" in {
+
+      val searchCount = new AtomicInteger(0)
+      val userRepo = mock[UserRepository]
+      when(userRepo.findSuperUsers()).thenAnswer(new Answer[Future[Seq[LdapUser]]] {
+        override def answer(invocation: InvocationOnMock): Future[Seq[LdapUser]] = {
+          if (searchCount.incrementAndGet() == 1) {
+            Future.failed(new RuntimeException("ldap down"))
+          } else {
+            Future.successful(Seq(Stubs.ldapUser))
+          }
+        }
+      })
+      val roleService = mock[RoleService]
+      when(roleService.getRolePermissions()).thenReturn(rolePermissions)
+
+      val userService = new UserServiceImpl(userRepo, null, null, null, null, roleService)
+
+      val thrown = the[RuntimeException] thrownBy Await.result(userService.findSuperUsers(), duration)
+      thrown.getMessage mustBe "ldap down"
+
+      // the failure is evicted asynchronously; retry until the service recovers
+      val deadline = System.currentTimeMillis() + 5000
+      var result: Seq[String] = Seq.empty
+      while (result.isEmpty && System.currentTimeMillis() < deadline) {
+        try {
+          result = Await.result(userService.findSuperUsers(), duration)
+        } catch {
+          case _: RuntimeException => Thread.sleep(50)
+        }
+      }
+      result mustBe Seq("user")
+    }
+
+  }
+
+}


### PR DESCRIPTION
... por match al aceptar lotes

La aceptación de un lote llama sendNotifToAllSuperUsers() por cada match y por cada protoperfil (Spark2Matcher, BulkUploadService, PedigreeSparkMatcher, etc.); cada llamada ejecutaba una búsqueda LDAP (title=true) completa sobre la única conexión de búsqueda, en ráfagas de 300+/seg que la mataban por backpressure y dejaban la app en resultCode=81 hasta reiniciar (incidente CDMX 2026-07-09, ~18 caídas el 9/7).

- UserService.findSuperUsers(): se memoiza el Future (no el valor) con TTL de 30s; las llamadas concurrentes comparten la búsqueda en vuelo, la ráfaga colapsa a 1 búsqueda. onFailure limpia el cache para no memorizar un fallo.
- LdapConnectionPoolFactory: setAutoReconnect(true) en la conexión de búsqueda. Verificado empíricamente contra unboundid-ldapsdk 2.3.1 (camino asyncSearch): recupera la conexión cuando el server la mata pero sigue vivo (el modo de muerte del incidente); NO sobrevive un reinicio del LDAP — el intento de reconexión contra un server caído la deja en 'not established' definitivo. Sobrevivir eso requiere servir las búsquedas desde un pool (pendiente).
- Test nuevo UserServiceSuperUsersTest (standalone, sin banco): ráfaga de 300 llamadas → exactamente 1 búsqueda al repositorio (rojo contra el código anterior: 300), y un fallo no queda cacheado.