### PR TITLE
Fix #298 — detector de regresiones de CI robusto (delta de suite + baseline inenvenenable)

### DIFF
--- a/.github/scripts/check_regression.py
+++ b/.github/scripts/check_regression.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+Regression detector for the GENis core test tier.
+
+Parses `sbt core/test` output, compares the measured test counts against a
+committed baseline, and classifies the run. Designed to be *unpoisonable*:
+
+  * A run that did not compile / did not really run tests is classified as
+    ``broken`` and NEVER overwrites the baseline (this is the bug from #298:
+    a compile break produced 0 tests, and 0 got saved as the new baseline,
+    blinding the detector forever).
+  * The baseline is only ever written on a *valid measurement* and only in the
+    improving direction (more ``passed`` / fewer ``failed``). It can never
+    ratchet down or be reset to zero by a broken run.
+
+Statuses (written to GITHUB_OUTPUT as ``status``):
+  broken      -> did not compile / too few tests ran. Alert, do NOT touch baseline.
+  regression  -> valid run, but fewer passing or more failing than baseline. Alert.
+  seeded      -> no prior baseline; established one from this valid run.
+  improved    -> valid run strictly better than baseline; ratchet baseline up.
+  ok          -> valid run equal to baseline.
+
+``update_baseline`` output is ``true`` for seeded/improved, else ``false``.
+``alert`` output is ``true`` for broken/regression, else ``false``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+
+# A valid measurement must have run at least this many tests. Guards against a
+# broken compile / dead harness reporting a handful of tests (or zero). The core
+# tier runs ~1000+ tests, so 100 cleanly separates "real run" from "broken".
+MIN_TOTAL_ABS = 100
+
+TOTAL_RE = re.compile(r"Total number of tests run:\s*(\d+)")
+TESTS_RE = re.compile(r"Tests:\s*succeeded\s*(\d+),\s*failed\s*(\d+)")
+ABORTED_RE = re.compile(r"Suites:\s*completed\s*\d+,\s*aborted\s*(\d+)")
+COMPILE_FAIL_RE = re.compile(r"Compilation failed|error\] .*(?:is not a member|not found:|cannot|expected)")
+
+
+def parse_output(text: str) -> dict:
+    """Extract test counts from sbt/ScalaTest output. Sums across every summary
+    block (a run may emit more than one)."""
+    totals = [int(m) for m in TOTAL_RE.findall(text)]
+    tests = TESTS_RE.findall(text)
+    aborted = [int(m) for m in ABORTED_RE.findall(text)]
+
+    passed = sum(int(s) for s, _ in tests)
+    failed = sum(int(f) for _, f in tests)
+    total = sum(totals)
+    has_summary = bool(totals)
+
+    return {
+        "has_summary": has_summary,
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "aborted_suites": sum(aborted),
+    }
+
+
+def load_baseline(path: str) -> dict | None:
+    if not path or not os.path.exists(path):
+        return None
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not data.get("seeded"):
+        return None
+    return data
+
+
+def classify(measured: dict, sbt_exit: int, baseline: dict | None) -> dict:
+    total = measured["total"]
+
+    # --- Validity gate: could this run even measure anything? ---------------
+    # Not valid if: no summary at all (compile break / harness died), or too
+    # few tests ran in absolute terms, or (when we have a baseline) the count
+    # collapsed to less than half of it (something structural broke).
+    valid = measured["has_summary"] and total >= MIN_TOTAL_ABS
+    if valid and baseline is not None:
+        if total < baseline.get("total", 0) / 2:
+            valid = False
+
+    if not valid:
+        reason = "no compiló / no corrió (sin resumen de tests)" if not measured["has_summary"] \
+            else f"corrieron sólo {total} tests (mínimo esperado {MIN_TOTAL_ABS} / la mitad del baseline)"
+        return {
+            "status": "broken",
+            "reason": reason,
+            "alert": True,
+            "update_baseline": False,
+        }
+
+    # --- Valid measurement: compare against baseline ------------------------
+    if baseline is None:
+        return {
+            "status": "seeded",
+            "reason": "primer baseline válido",
+            "alert": False,
+            "update_baseline": True,
+        }
+
+    b_passed = baseline.get("passed", 0)
+    b_failed = baseline.get("failed", 0)
+
+    broke_passing = measured["passed"] < b_passed
+    new_failures = measured["failed"] > b_failed
+
+    if broke_passing or new_failures:
+        return {
+            "status": "regression",
+            "reason": "; ".join(
+                filter(None, [
+                    f"passing bajó {b_passed}→{measured['passed']}" if broke_passing else "",
+                    f"failing subió {b_failed}→{measured['failed']}" if new_failures else "",
+                ])
+            ),
+            "alert": True,
+            "update_baseline": False,
+        }
+
+    improved = measured["passed"] > b_passed or measured["failed"] < b_failed
+    return {
+        "status": "improved" if improved else "ok",
+        "reason": "mejoró respecto al baseline" if improved else "sin cambios respecto al baseline",
+        "alert": False,
+        "update_baseline": improved,
+    }
+
+
+def emit_github(name_values: dict, path_env: str) -> None:
+    path = os.environ.get(path_env)
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as fh:
+        for k, v in name_values.items():
+            fh.write(f"{k}={v}\n")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--output", required=True, help="captured sbt/ScalaTest output file")
+    ap.add_argument("--sbt-exit", type=int, default=0, help="exit code of the sbt process")
+    ap.add_argument("--baseline", default=".github/test-baseline.json")
+    ap.add_argument("--write-baseline", action="store_true",
+                    help="if the decision says so, rewrite the baseline file in place")
+    args = ap.parse_args()
+
+    with open(args.output, encoding="utf-8", errors="replace") as fh:
+        text = fh.read()
+
+    measured = parse_output(text)
+    baseline = load_baseline(args.baseline)
+    decision = classify(measured, args.sbt_exit, baseline)
+
+    result = {**measured, "sbt_exit": args.sbt_exit, **decision}
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+    b_passed = (baseline or {}).get("passed", 0)
+    b_failed = (baseline or {}).get("failed", 0)
+    emit_github({
+        "status": decision["status"],
+        "alert": str(decision["alert"]).lower(),
+        "update_baseline": str(decision["update_baseline"]).lower(),
+        "reason": decision["reason"],
+        "passed": measured["passed"],
+        "failed": measured["failed"],
+        "total": measured["total"],
+        "baseline_passed": b_passed,
+        "baseline_failed": b_failed,
+    }, "GITHUB_OUTPUT")
+
+    emit_github({}, "GITHUB_STEP_SUMMARY")
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as fh:
+            icon = {"broken": "🔴", "regression": "🚨", "seeded": "🌱",
+                    "improved": "📈", "ok": "✅"}.get(decision["status"], "•")
+            fh.write(f"## {icon} Test regression check — `{decision['status']}`\n\n")
+            fh.write(f"- **Motivo:** {decision['reason']}\n")
+            fh.write(f"- **Medido:** passed={measured['passed']}, failed={measured['failed']}, "
+                     f"total={measured['total']}, suites abortadas={measured['aborted_suites']}\n")
+            fh.write(f"- **Baseline:** passed={b_passed}, failed={b_failed}\n")
+
+    if args.write_baseline and decision["update_baseline"]:
+        with open(args.baseline, "w", encoding="utf-8") as fh:
+            json.dump({
+                "seeded": True,
+                "passed": measured["passed"],
+                "failed": measured["failed"],
+                "total": measured["total"],
+            }, fh, indent=2)
+            fh.write("\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/test-baseline.json
+++ b/.github/test-baseline.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Baseline de la suite de tests de core para el detector de regresiones (.github/workflows/test-regression.yml). Se auto-siembra en la primera corrida VÁLIDA de CI (compiló + corrió la suite) y sólo se actualiza en la dirección de mejora (más passed / menos failed). Una corrida rota (no compila) NO puede sobrescribir este archivo. Podés editarlo a mano en un PR para fijar el baseline.",
+  "seeded": false
+}

--- a/.github/workflows/test-regression.yml
+++ b/.github/workflows/test-regression.yml
@@ -4,6 +4,16 @@ on:
   push:
     branches: [ new-dev ]
 
+# Needed so the job can commit the ratcheted baseline back to new-dev.
+# A push made with GITHUB_TOKEN does NOT re-trigger this workflow (GitHub's
+# loop-prevention), and the commit message carries [skip ci] as a belt-and-suspenders.
+permissions:
+  contents: write
+
+concurrency:
+  group: test-regression-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   test:
     name: Run Tests & Check Regression
@@ -12,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Java 17
         uses: actions/setup-java@v4
@@ -42,98 +54,100 @@ jobs:
         id: run_tests
         continue-on-error: true
         run: |
+          # Capture sbt's real exit code even though the default GitHub shell
+          # runs with `-eo pipefail` (which would otherwise abort this block the
+          # moment sbt returns non-zero). The health decision does NOT depend on
+          # this exit code — it is parsed from the output — but we record it.
+          set +e
           sbt -Dsbt.color=false -Dsbt.log.noformat=true "core/test" 2>&1 | tee test-output.txt
-          PASSED=$(grep -oP 'succeeded \K[0-9]+' test-output.txt | awk '{sum+=$1} END {print sum+0}')
-          FAILED=$(grep -oP 'failed \K[0-9]+' test-output.txt | awk '{sum+=$1} END {print sum+0}')
-          echo "passed=$PASSED" >> "$GITHUB_OUTPUT"
-          echo "failed=$FAILED"  >> "$GITHUB_OUTPUT"
-          echo "Tests found — passed: $PASSED, failed: $FAILED"
+          code=${PIPESTATUS[0]}
+          echo "sbt_exit=$code" >> "$GITHUB_OUTPUT"
+          echo "sbt exited with $code"
 
-      - name: Save current results as JSON
+      - name: Evaluate regression
+        id: eval
         run: |
-          echo '{"passed":${{ steps.run_tests.outputs.passed }},"failed":${{ steps.run_tests.outputs.failed }}}' \
-            > test-current.json
-          cat test-current.json
+          python3 .github/scripts/check_regression.py \
+            --output test-output.txt \
+            --sbt-exit "${{ steps.run_tests.outputs.sbt_exit || '0' }}" \
+            --baseline .github/test-baseline.json \
+            --write-baseline
 
-      - name: Download previous baseline
-        id: download_baseline
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          name: test-baseline
-          workflow: test-regression.yml
-          branch: new-dev
-          if_no_artifact_found: warn
-        continue-on-error: true
-
-      - name: Compare with baseline & detect regression
-        id: check_regression
-        run: |
-          CURRENT="${{ steps.run_tests.outputs.passed }}"
-          CURRENT="${CURRENT:-0}"
-
-          if [ -f "test-baseline.json" ]; then
-            BASELINE=$(python3 -c "import sys,json; print(json.load(open('test-baseline.json'))['passed'])")
-            echo "Baseline: $BASELINE  |  Current: $CURRENT"
-
-            if [ "$CURRENT" -lt "$BASELINE" ]; then
-              BROKEN=$(( BASELINE - CURRENT ))
-              echo "regression=true"    >> "$GITHUB_OUTPUT"
-              echo "baseline=$BASELINE" >> "$GITHUB_OUTPUT"
-              echo "current=$CURRENT"   >> "$GITHUB_OUTPUT"
-              echo "broken=$BROKEN"     >> "$GITHUB_OUTPUT"
-              echo "🚨 REGRESSION: $BROKEN test(s) broken!"
-            else
-              echo "regression=false" >> "$GITHUB_OUTPUT"
-              echo "✅ No regression (baseline=$BASELINE, current=$CURRENT)"
-            fi
-          else
-            echo "No baseline found (first run). Saving current state as new baseline."
-            echo "regression=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: 🚨 Notify Telegram on regression
-        if: steps.check_regression.outputs.regression == 'true'
+      - name: 🔴 Notify Telegram — build/harness broken
+        if: steps.eval.outputs.status == 'broken'
         env:
           TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           THREAD_ID: ${{ secrets.TELEGRAM_THREAD_ID }}
         run: |
-          SHORT_SHA="${{ github.sha }}"
-          SHORT_SHA="${SHORT_SHA:0:7}"
-          ACTOR="${{ github.actor }}"
-          BRANCH="${{ github.ref_name }}"
+          SHORT_SHA="${{ github.sha }}"; SHORT_SHA="${SHORT_SHA:0:7}"
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          BASELINE="${{ steps.check_regression.outputs.baseline }}"
-          CURRENT="${{ steps.check_regression.outputs.current }}"
-          BROKEN="${{ steps.check_regression.outputs.broken }}"
+          MESSAGE="🔴 *TESTS ROTOS — GENis (core)*
 
-          MESSAGE="🚨 *REGRESIÓN DE TESTS — GENis*
+          El tier de tests no compiló o no corrió correctamente, así que el detector quedaría ciego.
+          Motivo: ${{ steps.eval.outputs.reason }}
+          Medido: passed=${{ steps.eval.outputs.passed }}, failed=${{ steps.eval.outputs.failed }}, total=${{ steps.eval.outputs.total }}
 
-          Antes: ${BASELINE} tests pasaban ✅
-          Ahora: ${CURRENT} tests pasan ⚠️
-          Se rompieron: *${BROKEN} tests*
+          El baseline NO se tocó (protegido contra envenenamiento).
 
-          📌 \`${SHORT_SHA}\` por ${ACTOR}
-          🌿 Branch: \`${BRANCH}\`
+          📌 \`${SHORT_SHA}\` por ${{ github.actor }}
+          🌿 Branch: \`${{ github.ref_name }}\`
           🔗 [Ver run en GitHub Actions](${RUN_URL})"
-
           MESSAGE="$(echo "$MESSAGE" | sed 's/^[[:space:]]*//')"
-
           curl -s -X POST "https://api.telegram.org/bot${TOKEN}/sendMessage" \
             -d chat_id="${CHAT_ID}" \
             -d message_thread_id="${THREAD_ID}" \
             -d parse_mode="Markdown" \
             --data-urlencode text="${MESSAGE}"
 
-      - name: Update baseline artifact
-        if: steps.check_regression.outputs.regression == 'false'
-        run: cp test-current.json test-baseline.json
+      - name: 🚨 Notify Telegram — regression
+        if: steps.eval.outputs.status == 'regression'
+        env:
+          TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          THREAD_ID: ${{ secrets.TELEGRAM_THREAD_ID }}
+        run: |
+          SHORT_SHA="${{ github.sha }}"; SHORT_SHA="${SHORT_SHA:0:7}"
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MESSAGE="🚨 *REGRESIÓN DE TESTS — GENis*
 
-      - name: Upload baseline artifact
-        if: steps.check_regression.outputs.regression == 'false'
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-baseline
-          path: test-baseline.json
-          overwrite: true
-          retention-days: 90
+          Motivo: ${{ steps.eval.outputs.reason }}
+          Antes: passed=${{ steps.eval.outputs.baseline_passed }}, failed=${{ steps.eval.outputs.baseline_failed }} ✅
+          Ahora: passed=${{ steps.eval.outputs.passed }}, failed=${{ steps.eval.outputs.failed }} ⚠️
+
+          📌 \`${SHORT_SHA}\` por ${{ github.actor }}
+          🌿 Branch: \`${{ github.ref_name }}\`
+          🔗 [Ver run en GitHub Actions](${RUN_URL})"
+          MESSAGE="$(echo "$MESSAGE" | sed 's/^[[:space:]]*//')"
+          curl -s -X POST "https://api.telegram.org/bot${TOKEN}/sendMessage" \
+            -d chat_id="${CHAT_ID}" \
+            -d message_thread_id="${THREAD_ID}" \
+            -d parse_mode="Markdown" \
+            --data-urlencode text="${MESSAGE}"
+
+      # Best-effort: persists the (re)seeded / improved baseline back to new-dev.
+      # If new-dev is protected against Actions pushes this step fails softly
+      # (continue-on-error). In that case the maintainer should commit
+      # .github/test-baseline.json once by hand using the passed/failed numbers
+      # shown in this run's job summary — after that, every run compares against
+      # the committed file read-only and no push is needed.
+      - name: Commit updated baseline
+        if: steps.eval.outputs.update_baseline == 'true'
+        continue-on-error: true
+        run: |
+          if git diff --quiet -- .github/test-baseline.json; then
+            echo "Baseline sin cambios; nada que commitear."
+            exit 0
+          fi
+          git config user.name  "genis-ci[bot]"
+          git config user.email "genis-ci@users.noreply.github.com"
+          git add .github/test-baseline.json
+          git commit -m "chore(ci): baseline de tests → passed=${{ steps.eval.outputs.passed }} failed=${{ steps.eval.outputs.failed }} [skip ci]"
+          git push origin HEAD:new-dev \
+            || (git pull --rebase origin new-dev && git push origin HEAD:new-dev)
+
+      - name: Fail job on broken/regression
+        if: steps.eval.outputs.alert == 'true'
+        run: |
+          echo "::error::Tier de tests '${{ steps.eval.outputs.status }}': ${{ steps.eval.outputs.reason }}"
+          exit 1


### PR DESCRIPTION
Resuelve #298 — el detector de regresiones de CI (`test-regression.yml`, alerta por Telegram en push a `new-dev`) estaba **efectivamente ciego** desde ~junio 2026: contaba 0 passed, envenenaba el baseline a 0, y quedaba verde igual.

## Cómo se resuelve cada causa

1. **Sólo contaba PASSED (en 0 hace semanas).** Ahora la salud se decide por el **output parseado** (`Total number of tests run`), no por el contador de passed ni el exit code de sbt. Si el tier **no compila / corren < 100 tests** → estado `broken` → **job en rojo + Telegram**, sin tocar el baseline. La ruptura de compilación tipo #295 ahora se ve.
2. **Baseline envenenado a 0.** El baseline sólo se escribe en una corrida **válida** y sólo hacia la mejora (más `passed` / menos `failed`). Una corrida rota **nunca** lo sobrescribe.
3. **No alertaba fallos nuevos.** Ahora alerta si `passed` baja **o** si `failed` sube vs baseline → un test que empieza a fallar (tipo #296) dispara `regression`.
4. **Job siempre verde.** Un paso final hace `exit 1` en `broken`/`regression` (después del Telegram).
5. **Baseline durable.** Pasa de artifact con retención de 90 días a un **archivo commiteado** (`.github/test-baseline.json`) que se auto-siembra en la 1ra corrida válida y se ratchetea best-effort con `[skip ci]`.

## Archivos

- `.github/workflows/test-regression.yml` — reescrito.
- `.github/scripts/check_regression.py` — parseo + clasificación (`broken` / `regression` / `seeded` / `improved` / `ok`), testeable.
- `.github/test-baseline.json` — semilla del baseline (`seeded: false`).

## Verificación local

Capturé la salida real de ScalaTest en este repo (`1176 total, 1011 passed, 165 failed, 2 suites abortadas`) y probé el script contra 9 casos: seed inicial, estado estable, mejora, regresión por caída de `passed`, regresión por suba de `failed`, fallo de compilación y colapso de conteo — todos clasifican correcto. Verifiqué que una corrida `broken` **no** envenena el baseline y que una `improved` lo reescribe. YAML válido, Python compila, todos los bloques de shell pasan `bash -n`.

## Decisión de alcance

**No se agrega Docker para correr los integration tests en CI.** No hay seeding automático de esquema en el setup moderno (el `genisdb` local está pre-sembrado a mano; el esquema viene de las evolutions legacy de Play), y **aun localmente con Docker arriba ~165 tests fallan y 2 suites abortan** por bugs preexistentes (base64/decrypt de controllers). Docker no los pondría verdes. Por eso el detector corre la suite **completa** y trackea el delta `(passed, failed)` en vez de separar unit/integration (clasificación poco confiable: sólo 2 de 27 suites tienen `Tag("integration")`). Integration-verde-en-CI queda como follow-up.

## Nota operativa

Si `new-dev` está protegida contra pushes de Actions, el commit del baseline falla suave (`continue-on-error`). En ese caso hay que commitear `.github/test-baseline.json` una vez a mano con los números que aparecen en el job summary de la primera corrida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
