### PR TITLE
Fix #302 Guards Try(SampleCode) al construir global-code desde BD (port 5.1.14 D)

### DIFF
--- a/modules/core/app/bulkupload/SlickProtoProfileRepository.scala
+++ b/modules/core/app/bulkupload/SlickProtoProfileRepository.scala
@@ -17,6 +17,7 @@ import types.{AlphanumericId, SampleCode}
 import java.sql.Timestamp
 import java.util.Date
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 @Singleton
 class SlickProtoProfileRepository @Inject()(
@@ -42,7 +43,7 @@ class SlickProtoProfileRepository @Inject()(
       row.id, row.sampleName, row.assignee, row.category,
       ProtoProfileStatus.withName(row.status),
       row.panel, geno, mm, mr, se, row.genemapperLine,
-      preexistence = row.preexistence.map(SampleCode(_)),
+      preexistence = row.preexistence.flatMap(s => Try(SampleCode(s)).toOption),
       rejectMotive = row.rejectMotive
     )
   }
@@ -337,7 +338,7 @@ class SlickProtoProfileRepository @Inject()(
     ).map { rows =>
       rows.foldLeft[(Option[SampleCode], Option[Long])]((None, None)) { (acc, b) =>
         b._1.trim match {
-          case "PROFILE_ID" => (Some(SampleCode(b._2)), acc._2)
+          case "PROFILE_ID" => (Try(SampleCode(b._2)).toOption, acc._2)
           case "BATCH_ID"   => (acc._1, Some(b._2.trim.toLong))
           case _            => acc
         }
@@ -474,7 +475,7 @@ class SlickProtoProfileRepository @Inject()(
         profileRows <- db.run(profileQ.result)
         protoRows   <- db.run(protoQ.result)
         existsBySample = names.map { sn =>
-          val gc    = profileRows.find(_._1 == sn).map(r => SampleCode(r._2))
+          val gc    = profileRows.find(_._1 == sn).flatMap(r => Try(SampleCode(r._2)).toOption)
           val batch = protoRows.find(_._1 == sn).map(_._2)
           sn -> (gc, batch)
         }.toMap

--- a/modules/core/app/profiledata/ImportToProfileData.scala
+++ b/modules/core/app/profiledata/ImportToProfileData.scala
@@ -31,9 +31,11 @@ class SlickImportToProfileData @Inject()(
     if labo == labCode then
       DBIO.successful(s"$country-$prov-$labCode-")
     else
-      laboratories.filter(_.codeName === labo).result.headOption.map { labOpt =>
-        val lab = labOpt.get
-        s"${lab.country}-${lab.province}-${lab.codeName}-"
+      laboratories.filter(_.codeName === labo).result.headOption.map {
+        case Some(lab) if lab.country.nonEmpty && lab.province.nonEmpty && lab.codeName.nonEmpty =>
+          s"${lab.country}-${lab.province}-${lab.codeName}-"
+        case _ =>
+          s"$country-$prov-$labCode-"
       }
 
   override def fromProtoProfileData(id: Long, labCode: String, country: String, prov: String, assignee: String, desktopSearch: Boolean = false): Future[(SampleCode, String)] =

--- a/modules/core/app/profiledata/SlickProfileDataRepository.scala
+++ b/modules/core/app/profiledata/SlickProfileDataRepository.scala
@@ -12,10 +12,11 @@ import types.{AlphanumericId, SampleCode}
 import java.sql.Timestamp
 import java.util.Calendar
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 @Singleton
 class SlickProfileDataRepository @Inject()(
-  db: Database,
+  db: slick.jdbc.JdbcBackend.Database,
   messagesApi: MessagesApi
 )(implicit ec: ExecutionContext) extends ProfileDataRepository with Logging:
 
@@ -142,7 +143,7 @@ class SlickProfileDataRepository @Inject()(
         .map(_.globalCode)
         .result
         .headOption
-        .map(_.map(SampleCode(_)))
+        .map(_.flatMap(s => Try(SampleCode(s)).toOption))
     )
 
   // Full interface methods

--- a/modules/core/app/profiledata/SlickStashProfileDataRepository.scala
+++ b/modules/core/app/profiledata/SlickStashProfileDataRepository.scala
@@ -14,7 +14,7 @@ import scala.concurrent.{ExecutionContext, Future}
 // PROFILE_DATA_FILIATION_RESOURCES); all other tables remain APP schema.
 @Singleton
 class SlickStashProfileDataRepository @Inject()(
-  db: Database,
+  db: slick.jdbc.JdbcBackend.Database,
   messagesApi: MessagesApi
 )(implicit ec: ExecutionContext) extends SlickProfileDataRepository(db, messagesApi):
 

--- a/modules/core/test/integration/profiledata/SlickProfileDataRepositoryIntegrationTest.scala
+++ b/modules/core/test/integration/profiledata/SlickProfileDataRepositoryIntegrationTest.scala
@@ -1,0 +1,82 @@
+package integration.profiledata
+
+import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration.*
+
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.test.Helpers.stubMessagesApi
+import slick.jdbc.PostgresProfile.api.*
+
+import fixtures.PostgresSpec
+import profiledata.SlickProfileDataRepository
+import types.SampleCode
+
+/** Integration test for [[SlickProfileDataRepository.getGlobalCode]].
+ *
+ *  Guards the port of legacy 5.1.14 item D (issue #302): a `GLOBAL_CODE`
+ *  read from the DB that does NOT match the [[SampleCode]] format must be
+ *  swallowed (`Try(SampleCode(_)).toOption`) instead of throwing
+ *  `IllegalArgumentException` and aborting the lookup.
+ *
+ *  Requires a running Postgres on localhost:5432, database `genisdb`, with the
+ *  APP schema applied (`cd utils/docker && docker-compose up -d`). */
+class SlickProfileDataRepositoryIntegrationTest
+    extends AnyWordSpec with Matchers with PostgresSpec with BeforeAndAfterEach:
+
+  given ec: ExecutionContext = ExecutionContext.global
+  private val timeout = 10.seconds
+
+  private lazy val repo = new SlickProfileDataRepository(db, stubMessagesApi())
+
+  // Recognisable, self-contained test data (cleaned up defensively).
+  private val grpId          = "TEST_GRP_302"
+  private val catId          = "TEST_CAT_302"
+  private val validGc        = "AR-A-BUE-123"
+  private val malformedGc     = "CODIGO_MALFORMADO_302"
+  private val validSample    = "TEST_ISC_VALID_302"
+  private val malformedSample = "TEST_ISC_BAD_302"
+
+  private def cleanTestData(): Unit =
+    val cleanup = DBIO.seq(
+      sqlu"""DELETE FROM "APP"."PROFILE_DATA" WHERE "CATEGORY" = $catId""",
+      sqlu"""DELETE FROM "APP"."CATEGORY" WHERE "ID" = $catId""",
+      sqlu"""DELETE FROM "APP"."GROUP" WHERE "ID" = $grpId"""
+    )
+    Await.result(db.run(cleanup.transactionally), timeout)
+
+  private def seed(): Unit =
+    val setup = DBIO.seq(
+      sqlu"""INSERT INTO "APP"."GROUP" ("ID","NAME") VALUES ($grpId, 'Test Group 302')""",
+      sqlu"""INSERT INTO "APP"."CATEGORY"
+               ("ID","GROUP","NAME","FILIATION_DATA","REPLICATE","PEDIGREE_ASSOCIATION","IS_REFERENCE","TYPE")
+             VALUES ($catId, $grpId, 'Test Cat 302', false, false, false, false, 1)""",
+      sqlu"""INSERT INTO "APP"."PROFILE_DATA"
+               ("ID","CATEGORY","GLOBAL_CODE","INTERNAL_CODE","INTERNAL_SAMPLE_CODE","ASSIGNEE","LABORATORY","DELETED","FROM_DESKTOP_SEARCH")
+             VALUES (930201, $catId, $validGc, 'TEST_IC_VALID_302', $validSample, 'TEST_ASSIGNEE', 'TEST_LAB_302', false, false)""",
+      sqlu"""INSERT INTO "APP"."PROFILE_DATA"
+               ("ID","CATEGORY","GLOBAL_CODE","INTERNAL_CODE","INTERNAL_SAMPLE_CODE","ASSIGNEE","LABORATORY","DELETED","FROM_DESKTOP_SEARCH")
+             VALUES (930202, $catId, $malformedGc, 'TEST_IC_BAD_302', $malformedSample, 'TEST_ASSIGNEE', 'TEST_LAB_302', false, false)"""
+    )
+    Await.result(db.run(setup.transactionally), timeout)
+
+  override protected def beforeEach(): Unit =
+    super.beforeEach()
+    cleanTestData()
+    seed()
+
+  override protected def afterEach(): Unit =
+    cleanTestData()
+    super.afterEach()
+
+  "SlickProfileDataRepository.getGlobalCode" must {
+
+    "return Some(SampleCode) for a well-formed GLOBAL_CODE" in {
+      Await.result(repo.getGlobalCode(validSample), timeout) mustBe Some(SampleCode(validGc))
+    }
+
+    "return None (not throw) when the stored GLOBAL_CODE is malformed" in {
+      Await.result(repo.getGlobalCode(malformedSample), timeout) mustBe None
+    }
+  }


### PR DESCRIPTION
Cierra #302. Ítem **D** de la hoja de ruta de incorporación de cambios legacy v5.1.14 (`.claude/legacy-5.1.14-roadmap.md`).

## Qué hace

Port literal del hardening de legacy **v5.1.14** (`5446c4c` → `eb43c70`): envolver la construcción cruda de `SampleCode` a partir de valores leídos de BD en `Try(...).toOption` / pattern-match. `SampleCode` extiende `ConstrainedText`, cuyo constructor **lanza `IllegalArgumentException`** si el texto no matchea `^[A-Z]{2,3}-[A-Z]-[A-Z]+-\d+$`; hoy un `GLOBAL_CODE`/`preexistence` no conforme en BD tira excepción y aborta toda la operación en vez de degradar prolijamente.

- **`bulkupload/SlickProtoProfileRepository`** — `row2protoProfile` (`preexistence`), `exists` (rama `PROFILE_ID`) y `preloadValidationData` (equivalente batch de `exists`, modern-only de #218).
- **`profiledata/ImportToProfileData.labPrefixAction`** — reemplaza el `.get` del lookup de laboratorio por pattern-match con guardas `nonEmpty` sobre `country/province/codeName` + fallback a `s"$country-$prov-$labCode-"` (forma literal 5.1.14).
- **`profiledata/SlickProfileDataRepository.getGlobalCode`** — guard del `SampleCode`.

Extra: se alineó el tipo del parámetro `db` de `SlickProfileDataRepository` y su subclase Stash a `slick.jdbc.JdbcBackend.Database` (tipo ya bindeado en Guice y convención del resto de repos), para habilitar el test de integración estándar vía `PostgresSpec`. Cambio de tipo puro; cero cambio de runtime.

## Verificación

`SlickProfileDataRepositoryIntegrationTest` (Postgres): un `GLOBAL_CODE` malformado → `getGlobalCode` devuelve `None` sin excepción; uno válido round-trips. **Verificado en rojo** (reversión temporal del guard → `IllegalArgumentException`) antes de aplicar el fix. Los 159 tests de `bulkupload` + `profiledata` siguen verdes.

## Nota sobre la limitación de esta "solución"

Esto es **hardening defensivo con fidelidad al legacy, no la cura de un incidente documentado**: en el legacy los tres guards entraron dentro de un commit cajón-de-sastre (`2ec2051`, "Últimos cambios en reportes"), sin issue ni causa raíz.

Y `None` **no es automáticamente "lo correcto"**: para `getGlobalCode`/`exists`, devolver `None` **enmascara** que la fila existe (hay un perfil, solo que con un código que el regex rechaza). Se cambia "explotar ruidosamente" por "comportarse como si no estuviera"; en el chequeo de preexistencia de `exists` eso incluso podría dejar pasar un duplicado. La causa de fondo es que el global-code se genera desde `COUNTRY-PROVINCE-CODE_NAME-<seq>` y `CODE_NAME` es un `varchar(20)` sin restricción de formato, así que el sistema puede persistir códigos que su propio regex no parsea.

Un fix de correctitud real (fuera del alcance de este PR de paridad) sería: restringir `CODE_NAME` al alfabeto de `SampleCode` (o redefinir el regex), y/o **loguear** cuando se descarta un código no parseable en vez de tragárselo en silencio.

Ref: `.claude/legacy-5.1.14-port-plan.md` §3.D