### PR TITLE
Fix #304 memoizar findSuperUsers() con TTL (port legacy 5.1.14 — roadmap B)

### DIFF
--- a/modules/core/app/CoreModule.scala
+++ b/modules/core/app/CoreModule.scala
@@ -1,17 +1,30 @@
 package modules.core
 
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
 import com.google.inject.AbstractModule
+import com.google.inject.name.Names
+import play.api.{Configuration, Environment}
 import matching.{MatchingProcessStatus, MatchingProcessStatusImpl}
 import services.{CountryService, LaboratoryService, GeneticistService, UserService}
 import services.{LaboratoryServiceImpl, GeneticistServiceImpl, CountryServiceImpl, UserServiceImpl}
 import stats.{PopulationBaseFrequencyRepository, PopulationBaseFrequencyRepositoryImpl}
 import stats.{PopulationBaseFrequencyService, PopulationBaseFrequencyServiceImpl}
 
-class CoreModule extends AbstractModule {
+class CoreModule(environment: Environment, configuration: Configuration) extends AbstractModule {
   override def configure(): Unit = {
     val logger = org.slf4j.LoggerFactory.getLogger("modules.core.CoreModule")
     try {
       logger.info("[CoreModule] Starting configuration...")
+
+      // TTL del memo de superusuarios de UserServiceImpl (issue #304)
+      val superUsersCacheTtl = configuration
+        .getOptional[FiniteDuration]("user.superUsersCacheTtl")
+        .getOrElse(30.seconds)
+      bind(classOf[FiniteDuration])
+        .annotatedWith(Names.named("superUsersCacheTtl"))
+        .toInstance(superUsersCacheTtl)
+
       bind(classOf[LaboratoryService]).to(classOf[LaboratoryServiceImpl])
       bind(classOf[GeneticistService]).to(classOf[GeneticistServiceImpl])
       bind(classOf[CountryService]).to(classOf[CountryServiceImpl])

--- a/modules/core/app/services/UserService.scala
+++ b/modules/core/app/services/UserService.scala
@@ -265,10 +265,28 @@ class UserServiceImpl @Inject() (
   override def isSuperUserByGeneMapper(geneMapperId: String): Future[Boolean] =
     findByGeneMapper(geneMapperId).map(_.exists(_.superuser))
 
+  // sendNotifToAllSuperUsers is invoked once per match / per proto-profile
+  // when a batch is accepted (BulkUploadService, PedigreeMatcher): each call
+  // used to fire a full LDAP search "(title=true)" over the single shared
+  // search connection, in bursts of 300+ searches per second that killed it
+  // by backpressure (resultCode=81; incident 2026-07-09, CDMX deployment).
+  // Memoize the Future for a short TTL: concurrent calls share the in-flight
+  // search and the list (which almost never changes) refreshes by itself.
+  protected val superUsersTtlMillis = 30000L
+  @volatile private var superUsersCached: Option[(Long, Future[Seq[String]])] = None
+
   override def findSuperUsers(): Future[Seq[String]] =
-    userRepository.findSuperUsers().map(
-      _.map(LdapUser.toUser(_, roleService.getRolePermissions())).map(_.id).toSet.toSeq
-    )
+    val now = System.currentTimeMillis()
+    superUsersCached match
+      case Some((ts, cached)) if now - ts < superUsersTtlMillis => cached
+      case _ =>
+        val fresh = userRepository.findSuperUsers().map(
+          _.map(LdapUser.toUser(_, roleService.getRolePermissions())).map(_.id).toSet.toSeq
+        )
+        superUsersCached = Some((now, fresh))
+        // never cache a failure (e.g. LDAP briefly down)
+        fresh.failed.foreach(_ => superUsersCached = None)
+        fresh
 
   override def sendNotifToAllSuperUsers(info: NotificationInfo, excepThis: Seq[String]): Unit =
     val usersToNotify = findSuperUsers().map(_.filter(user => !excepThis.contains(user)))

--- a/modules/core/app/services/UserService.scala
+++ b/modules/core/app/services/UserService.scala
@@ -3,6 +3,7 @@ package services
 import java.util.UUID
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.reflect.ClassTag
 
 import javax.inject.{Inject, Singleton}
@@ -44,7 +45,8 @@ class UserServiceImpl @Inject() (
     otpService: OTPService,
     notiService: NotificationService,
     roleService: RoleService,
-    messagesApi: MessagesApi
+    messagesApi: MessagesApi,
+    @jakarta.inject.Named("superUsersCacheTtl") superUsersCacheTtl: FiniteDuration = 30.seconds
 )(using ec: ExecutionContext) extends UserService:
 
   private val logger = Logger(this.getClass)
@@ -270,9 +272,10 @@ class UserServiceImpl @Inject() (
   // used to fire a full LDAP search "(title=true)" over the single shared
   // search connection, in bursts of 300+ searches per second that killed it
   // by backpressure (resultCode=81; incident 2026-07-09, CDMX deployment).
-  // Memoize the Future for a short TTL: concurrent calls share the in-flight
-  // search and the list (which almost never changes) refreshes by itself.
-  protected val superUsersTtlMillis = 30000L
+  // Memoize the Future for a short TTL (`user.superUsersCacheTtl`): concurrent
+  // calls share the in-flight search and the list (which almost never changes)
+  // refreshes by itself.
+  private val superUsersTtlMillis = superUsersCacheTtl.toMillis
   @volatile private var superUsersCached: Option[(Long, Future[Seq[String]])] = None
 
   override def findSuperUsers(): Future[Seq[String]] =
@@ -284,8 +287,13 @@ class UserServiceImpl @Inject() (
           _.map(LdapUser.toUser(_, roleService.getRolePermissions())).map(_.id).toSet.toSeq
         )
         superUsersCached = Some((now, fresh))
-        // never cache a failure (e.g. LDAP briefly down)
-        fresh.failed.foreach(_ => superUsersCached = None)
+        // never cache a failure (e.g. LDAP briefly down): drop the memo so the
+        // next caller retries. This is the only error path of the method, and
+        // its callers discard the failed Future, so log it here or it is lost.
+        fresh.failed.foreach { e =>
+          logger.warn("Superuser LDAP search failed; dropping the memo so the next call retries", e)
+          superUsersCached = None
+        }
         fresh
 
   override def sendNotifToAllSuperUsers(info: NotificationInfo, excepThis: Seq[String]): Unit =

--- a/modules/core/conf/application.conf
+++ b/modules/core/conf/application.conf
@@ -253,3 +253,11 @@ ldap.default {
   rolesDn = ${?LDAP_ROLES_DN}
 }
 
+# TTL del memo de la lista de superusuarios (services.UserServiceImpl.findSuperUsers).
+# Acota las ráfagas de búsquedas LDAP "(title=true)" al aceptar lotes, que llegaban a
+# 300+/s y mataban la conexión de búsqueda compartida (resultCode=81; issue #304).
+# Es también la ventana máxima de staleness: un superusuario recién creado puede no
+# recibir notificaciones hasta que venza.
+user.superUsersCacheTtl = 30 seconds
+user.superUsersCacheTtl = ${?SUPERUSERS_CACHE_TTL}
+

--- a/modules/core/test/integration/services/UserServiceWiringTest.scala
+++ b/modules/core/test/integration/services/UserServiceWiringTest.scala
@@ -1,0 +1,51 @@
+package integration.services
+
+import scala.concurrent.ExecutionContext
+
+import org.scalatestplus.play.*
+import org.scalatestplus.play.guice.GuiceOneAppPerTest
+import play.api.Application
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+
+import fixtures.StubLdapHealthService
+import kits.StrKitModule
+import probability.ProbabilityModule
+import security.{StubRoleRepository, StubUserRepository, UserRepository}
+import services.UserService
+import user.{LdapHealthService, RoleRepository, UsersModule}
+
+/**
+ * Guards the two wiring facts the superuser memo (issue #304) depends on and that no
+ * unit test can see: the named `superUsersCacheTtl` binding resolves, and the service
+ * is a singleton — otherwise the memo would live per injection point and do nothing.
+ * No Docker required: LDAP and infrastructure services are stubbed.
+ */
+class UserServiceWiringTest extends PlaySpec with GuiceOneAppPerTest {
+
+  override def fakeApplication(): Application =
+    GuiceApplicationBuilder()
+      .disable[UsersModule]
+      .disable[StrKitModule]
+      .disable[ProbabilityModule]
+      .overrides(
+        bind[UserRepository].to[StubUserRepository],
+        bind[RoleRepository].to[StubRoleRepository],
+        new fixtures.StubStrKitModule,
+        new fixtures.StubProbabilityModule,
+        bind[ExecutionContext].qualifiedWith("lrmix-context").toInstance(ExecutionContext.global),
+        bind[LdapHealthService].toInstance(new StubLdapHealthService)
+      )
+      .build()
+
+  "UserService wiring" must {
+
+    "resolve UserServiceImpl with the named superUsersCacheTtl binding" in {
+      app.injector.instanceOf[UserService].getClass.getName must include("UserServiceImpl")
+    }
+
+    "be a singleton, so the superuser memo is process-wide" in {
+      app.injector.instanceOf[UserService] must be theSameInstanceAs app.injector.instanceOf[UserService]
+    }
+  }
+}

--- a/modules/core/test/unit/services/UserServiceImplTest.scala
+++ b/modules/core/test/unit/services/UserServiceImplTest.scala
@@ -1,6 +1,6 @@
 package unit.services
 
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.concurrent.duration.*
 
 import org.mockito.ArgumentMatchers.{any, anyString}
@@ -52,13 +52,12 @@ class UserServiceImplTest extends AnyWordSpec with Matchers with MockitoSugar wi
   private def buildServiceWithTtl(
       userRepository: UserRepository,
       roleService: RoleService,
-      ttlMillis: Long
+      ttl: FiniteDuration
   ): UserServiceImpl =
     new UserServiceImpl(
       userRepository, new StubCacheService, mock[CryptoService], mock[OTPService],
-      new NoOpNotificationService, roleService, messagesApi
-    ):
-      override protected val superUsersTtlMillis = ttlMillis
+      new NoOpNotificationService, roleService, messagesApi, ttl
+    )
 
   // ── signupRequest ──────────────────────────────────────────────
 
@@ -597,13 +596,40 @@ class UserServiceImplTest extends AnyWordSpec with Matchers with MockitoSugar wi
       verify(userRepo, times(1)).findSuperUsers()
     }
 
+    // This is the property the memo exists for: the burst that killed the LDAP search
+    // connection was concurrent, so callers must share the search that is still running,
+    // not just reuse an already finished result.
+    "share the in-flight search between concurrent callers" in {
+      val userRepo = mock[UserRepository]
+      val roleSvc = mock[RoleService]
+      when(roleSvc.getRolePermissions()).thenReturn(Map.empty[String, Set[Permission]])
+
+      val inFlight = Promise[Seq[LdapUser]]()
+      when(userRepo.findSuperUsers()).thenReturn(inFlight.future)
+
+      val service = buildService(userRepository = userRepo, roleService = roleSvc)
+
+      val first = service.findSuperUsers()
+      val second = service.findSuperUsers()
+
+      first.isCompleted mustBe false
+      second.isCompleted mustBe false
+      verify(userRepo, times(1)).findSuperUsers()
+
+      inFlight.success(Seq(UserFixtures.superLdapUser))
+
+      Await.result(first, timeout) mustBe Seq("superuser")
+      Await.result(second, timeout) mustBe Seq("superuser")
+      verify(userRepo, times(1)).findSuperUsers()
+    }
+
     "search LDAP again once the TTL window expired" in {
       val userRepo = mock[UserRepository]
       val roleSvc = mock[RoleService]
       when(roleSvc.getRolePermissions()).thenReturn(Map.empty[String, Set[Permission]])
       when(userRepo.findSuperUsers()).thenReturn(Future.successful(Seq(UserFixtures.superLdapUser)))
 
-      val service = buildServiceWithTtl(userRepo, roleSvc, ttlMillis = 50L)
+      val service = buildServiceWithTtl(userRepo, roleSvc, ttl = 50.millis)
 
       Await.result(service.findSuperUsers(), timeout) mustBe Seq("superuser")
       Thread.sleep(80)

--- a/modules/core/test/unit/services/UserServiceImplTest.scala
+++ b/modules/core/test/unit/services/UserServiceImplTest.scala
@@ -4,8 +4,10 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.*
 
 import org.mockito.ArgumentMatchers.{any, anyString}
-import org.mockito.Mockito.{verify, when}
+import org.mockito.Mockito.{times, verify, when}
+import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.must.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.DefaultMessagesApi
@@ -17,10 +19,13 @@ import services.{ClearPassRequestKey, FullUserKey, SignupRequestKey, UserService
 import types.{Permission, TotpToken}
 import user.*
 
-class UserServiceImplTest extends AnyWordSpec with Matchers with MockitoSugar:
+class UserServiceImplTest extends AnyWordSpec with Matchers with MockitoSugar with Eventually:
 
   given ExecutionContext = ExecutionContext.global
   private val timeout: Duration = Duration(5, "seconds")
+
+  override implicit val patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = Span(2, Seconds), interval = Span(20, Millis))
 
   private val messagesApi = new DefaultMessagesApi(Map(
     "default" -> Map(
@@ -42,6 +47,18 @@ class UserServiceImplTest extends AnyWordSpec with Matchers with MockitoSugar:
       userRepository, cacheService, cryptoService, otpService,
       new NoOpNotificationService, roleService, messagesApi
     )
+
+  /** Same service with a shortened superuser memo TTL, so the expiry is testable without sleeping 30s. */
+  private def buildServiceWithTtl(
+      userRepository: UserRepository,
+      roleService: RoleService,
+      ttlMillis: Long
+  ): UserServiceImpl =
+    new UserServiceImpl(
+      userRepository, new StubCacheService, mock[CryptoService], mock[OTPService],
+      new NoOpNotificationService, roleService, messagesApi
+    ):
+      override protected val superUsersTtlMillis = ttlMillis
 
   // ── signupRequest ──────────────────────────────────────────────
 
@@ -559,5 +576,58 @@ class UserServiceImplTest extends AnyWordSpec with Matchers with MockitoSugar:
       val service = buildService(userRepository = userRepo)
 
       Await.result(service.isSuperUser("testuser"), timeout) mustBe false
+    }
+  }
+
+  // ── findSuperUsers (memo TTL — issue #304) ─────────────────────
+
+  "UserServiceImpl.findSuperUsers" must {
+
+    "search LDAP only once for repeated calls inside the TTL window" in {
+      val userRepo = mock[UserRepository]
+      val roleSvc = mock[RoleService]
+      when(roleSvc.getRolePermissions()).thenReturn(Map.empty[String, Set[Permission]])
+      when(userRepo.findSuperUsers()).thenReturn(Future.successful(Seq(UserFixtures.superLdapUser)))
+
+      val service = buildService(userRepository = userRepo, roleService = roleSvc)
+
+      Await.result(service.findSuperUsers(), timeout) mustBe Seq("superuser")
+      Await.result(service.findSuperUsers(), timeout) mustBe Seq("superuser")
+
+      verify(userRepo, times(1)).findSuperUsers()
+    }
+
+    "search LDAP again once the TTL window expired" in {
+      val userRepo = mock[UserRepository]
+      val roleSvc = mock[RoleService]
+      when(roleSvc.getRolePermissions()).thenReturn(Map.empty[String, Set[Permission]])
+      when(userRepo.findSuperUsers()).thenReturn(Future.successful(Seq(UserFixtures.superLdapUser)))
+
+      val service = buildServiceWithTtl(userRepo, roleSvc, ttlMillis = 50L)
+
+      Await.result(service.findSuperUsers(), timeout) mustBe Seq("superuser")
+      Thread.sleep(80)
+      Await.result(service.findSuperUsers(), timeout) mustBe Seq("superuser")
+
+      verify(userRepo, times(2)).findSuperUsers()
+    }
+
+    "not cache a failed search: the next call goes back to LDAP" in {
+      val userRepo = mock[UserRepository]
+      val roleSvc = mock[RoleService]
+      when(roleSvc.getRolePermissions()).thenReturn(Map.empty[String, Set[Permission]])
+      when(userRepo.findSuperUsers())
+        .thenReturn(Future.failed(new RuntimeException("LDAP down")))
+        .thenReturn(Future.successful(Seq(UserFixtures.superLdapUser)))
+
+      val service = buildService(userRepository = userRepo, roleService = roleSvc)
+
+      a[RuntimeException] must be thrownBy Await.result(service.findSuperUsers(), timeout)
+
+      // the cache is cleared by an asynchronous callback, so retry until it lands
+      eventually {
+        Await.result(service.findSuperUsers(), timeout) mustBe Seq("superuser")
+      }
+      verify(userRepo, times(2)).findSuperUsers()
     }
   }


### PR DESCRIPTION
Cierra #304. Ítem **B** del roadmap de port de legacy 5.1.14 (`.claude/legacy-5.1.14-roadmap.md`, Bloque 1). Port del fix de #294.

## Problema

`sendNotifToAllSuperUsers` se invoca una vez por match y una vez por proto-perfil al aceptar un lote (9 call sites: bulkupload ×3, profiledata ×2, pedigree ×2, signup ×2). Cada invocación disparaba una búsqueda LDAP `(title=true)` completa sobre la conexión de búsqueda compartida → ráfagas de 300+/s que la mataban por backpressure (`resultCode=81`; incidente real en legacy: 2026-07-09, despliegue CDMX, caída de todo lo que depende de LDAP hasta reiniciar).

## Qué hace este PR

**`d760c54` — el port.** Memoiza el **`Future`** (no el valor) de `findSuperUsers()` por un TTL corto: las llamadas concurrentes de la ráfaga comparten la búsqueda en vuelo, la lista se refresca sola y un fallo nunca queda cacheado. Port literal del legacy salvo `fresh.failed.foreach(...)` en lugar de `onFailure`, que no existe en Scala 3.

**`a520f35` — hallazgos del review de calidad.**
- Test de la propiedad central: dos callers concurrentes contra un `Promise` sin completar comparten la búsqueda en vuelo. Los otros tests sólo probaban reutilización de un resultado ya completado — una implementación que cachee el *valor* los pasa a todos y deja pasar la ráfaga igual. Verificado por mutación.
- El TTL sale de `user.superUsersCacheTtl` (`application.conf`, override por `SUPERUSERS_CACHE_TTL`) en vez de un `protected val` hardcodeado que existía sólo para el test. `CoreModule` pasa a recibir `(Environment, Configuration)` y bindea `@Named("superUsersCacheTtl")`, como `BulkUploadModule`.
- `logger.warn` al limpiar el memo: era el único camino de error del método y era mudo (los callers descartan el `Future` fallido).
- `UserServiceWiringTest` (Guice, sin Docker): comprueba que el binding nombrado resuelve y que `UserService` es singleton — si no lo fuera habría un memo por punto de inyección y el fix no haría nada.

## Fuera de alcance

No se porta el `setAutoReconnect(true)` que legacy agregó en `LdapConnectionPoolFactory`: `LdapConnectionProviderImpl.search` ya hace `reconnect()` + reintento explícito sobre la conexión de búsqueda compartida, que es el camino del incidente. Justificación completa en `.claude/legacy-5.1.14-B-memo-spec.md` §2.

## Consecuencia a tener presente

El TTL es también la ventana máxima de staleness: un superusuario recién creado puede no recibir notificaciones hasta 30 s. Ninguna decisión de autorización depende de esta lista (el único consumidor es el envío de notificaciones; `isSuperUser` va por `getUser`).

## Verificación

- 4 unit tests en `UserServiceImplTest` (una sola búsqueda dentro del TTL / búsqueda en vuelo compartida / re-búsqueda al vencer / fallo que no envenena la cache) + 2 de wiring.
- Suite completa de `core`: **1212 tests, 1047 passed, 165 failed** — los mismos 165 de la baseline commiteada (controllers por base64/decrypt + 2 suites de integración que abortan sin Docker), sin regresiones.
